### PR TITLE
Re-open file in utils.open_image() if it is closed

### DIFF
--- a/pilkit/utils.py
+++ b/pilkit/utils.py
@@ -17,6 +17,8 @@ def img_to_fobj(img, format, autoconvert=True, **options):
 
 
 def open_image(target):
+    if target.closed:
+        target.open()
     target.seek(0)
     return Image.open(target)
 


### PR DESCRIPTION
This is a workaround for a Django issue described here:  https://code.djangoproject.com/ticket/13750

The specific scenario I encountered is using an `ImageSpecField` from ImageKit on an `ImageField` that has `width_field` & `height_field` params.  Django sets the width/height fields before ImagetKit/PILKit gets to the file, and by that point it's closed and there's an I/O error. 
