### PR TITLE
Sets MAXBLOCK based on original image size

### DIFF
--- a/pilkit/utils.py
+++ b/pilkit/utils.py
@@ -170,7 +170,7 @@ def save_image(img, outfile, format, original_size, options=None, autoconvert=Tr
         # http://github.com/jdriscoll/django-imagekit/issues/50 and
         # https://github.com/jdriscoll/django-imagekit/issues/134
         old_maxblock = ImageFile.MAXBLOCK
-        ImageFile.MAXBLOCK = max(original_size) ** 2
+        ImageFile.MAXBLOCK = max(original_size + img.size) ** 2
         try:
             img.save(outfile, format, **options)
         finally:


### PR DESCRIPTION
I hope someone working with Pillow will be able to fix the problem but here is a pull request for a better(?) workaround which should fix https://github.com/matthewwithanm/django-imagekit/issues/231.
My premiss is that utils.process_image always get called, so I set original_size = img.size and pass that to > img_to_fobj > save_image.
Have I neglected something? Is it a style-wise way to pass that parameter?
