### PR TITLE
TypeError in save_image with autoconvert=True on Python 3.2

### DIFF
--- a/pilkit/utils.py
+++ b/pilkit/utils.py
@@ -153,7 +153,10 @@ def save_image(img, outfile, format, options=None, autoconvert=True):
 
     if autoconvert:
         img, save_kwargs = prepare_image(img, format)
-        options = dict(save_kwargs.items() + options.items())
+        # Use returned from prepare_image arguments for base
+        # and update them with provided options. Then use the result
+        save_kwargs.update(options)
+        options = save_kwargs
 
     # Attempt to reset the file pointer.
     try:


### PR DESCRIPTION
The error rised was:

```
unsupported operand type(s) for +: 'dict_items' and 'dict_items'
```

In Python 3 `dict.items()` returns an iterator, not a list. One iterator can not be added to another iterator.
Instead of getting items of both dict we can update the dict returned from `prepare_image` with `options` and then to `options` to be equal to updated kwargs.

 This will work on Python3 and Python2.
