### PR TITLE
Avoid Transpose to crash when exif data are invalid.

### DIFF
--- a/pilkit/processors/base.py
+++ b/pilkit/processors/base.py
@@ -161,7 +161,7 @@ class Transpose(object):
             try:
                 orientation = img._getexif()[0x0112]
                 ops = self._EXIF_ORIENTATION_STEPS[orientation]
-            except (KeyError, TypeError, AttributeError):
+            except (IndexError, KeyError, TypeError, AttributeError):
                 ops = []
         else:
             ops = self.methods


### PR DESCRIPTION
Avoid crash during Transpose when PIL/Pillow cannot process EXIF data and showing 'IndexError: string index out of range' error. 

It is related to this open Pillow issue: https://github.com/python-imaging/Pillow/issues/518
