### PR TITLE
Turned the build result into a clickable link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,7 @@ Looking for more advanced processors? Check out `Instakit`_!
 `PILKit on RTD`_.
 
 .. image:: https://api.travis-ci.org/matthewwithanm/pilkit.png
+  :target: https://travis-ci.org/matthewwithanm/pilkit
 
 .. _`PILKit on RTD`: http://pilkit.readthedocs.org
 .. _`Instakit`: https://github.com/fish2000/instakit


### PR DESCRIPTION
Because it's useful to know where it's building (in this case, being Travis, which I've used, I could infer the URL for build status)