### PR TITLE
Include tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include AUTHORS
 include LICENSE
 include README.rst
 recursive-include docs *
-prune tests
+recursive-include tests *

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author_email='m@tthewwithanm.com',
     license='BSD',
     url='http://github.com/matthewwithanm/pilkit/',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     zip_safe=False,
     include_package_data=True,
     tests_require=[


### PR DESCRIPTION
This will allow developers to use the tests from the source tarball while they still won't be installed.
I'd use this in a future Debian package of pilkit to run the tests during build.