### PR TITLE
Prevent inclusion of automatically generated files like .pyc in tests directory.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include AUTHORS
 include LICENSE
 include README.rst
 recursive-include docs *
-recursive-include tests *
+recursive-include tests *.py *.gif *.png *.jpg


### PR DESCRIPTION
This makes for a cleaner source tarball. Otherwise artifacts like .pyc files and __pycache__ directories might get included in uploads to pypi.