### PR TITLE
Update utils.py

### DIFF
--- a/pilkit/utils.py
+++ b/pilkit/utils.py
@@ -245,6 +245,10 @@ class quiet(object):
             # In case of Azure, the file descriptor is not present so we can return
             # from here
             return
+        except UnsupportedOperation:
+            # In case of Windows 2016, the file descriptor is not present so we can return
+            # from here
+            return
         try:
             self.null_fd = os.open(os.devnull, os.O_RDWR)
         except OSError:


### PR DESCRIPTION
Running on IIS on Windows 2016 kept getting the error UnsupportedOperation 
Handling the exception seems to handle it. 
Please take a look.

C:\Sites\pyenv\lib\site-packages\imagekit\specs\__init__.py in generate
                                      options=self.options) ...
▼ Local vars
Variable	Value
closed	
False
img	
<PIL.PngImagePlugin.PngImageFile image mode=RGB size=480x317 at 0x1C4BEBBDAC8>
self	
<toor.imaging.specs.Thumbnail object at 0x000001C4BEBBD908>
C:\Sites\pyenv\lib\site-packages\pilkit\utils.py in process_image
    return img_to_fobj(img, format, autoconvert, **options) ...
▼ Local vars
Variable	Value
ProcessorPipeline	
<class 'pilkit.processors.base.ProcessorPipeline'>
autoconvert	
True
format	
'jpeg'
img	
<PIL.Image.Image image mode=RGBA size=728x481 at 0x1C4BEBBDA90>
options	
{'compress_level': 1, 'optimize': 0, 'progressive': 1, 'quality': 95}
original_format	
'PNG'
processors	
[<toor.imaging.specs.ImageResizeProcessor object at 0x000001C4BEBBD780>,
 <toor.imaging.specs.WatermarkProcessor object at 0x000001C4BEBBD9B0>]
C:\Sites\pyenv\lib\site-packages\pilkit\utils.py in img_to_fobj
    return save_image(img, StringIO(), format, options, autoconvert) ...
▼ Local vars
Variable	Value
autoconvert	
True
format	
'jpeg'
img	
<PIL.Image.Image image mode=RGBA size=728x481 at 0x1C4BEBBDA90>
options	
{'compress_level': 1, 'optimize': 0, 'progressive': 1, 'quality': 95}
C:\Sites\pyenv\lib\site-packages\pilkit\utils.py in save_image
            save(wrapper) ...
▼ Local vars
Variable	Value
autoconvert	
True
format	
'jpeg'
img	
<PIL.Image.Image image mode=RGB size=728x481 at 0x1C4BEBBDC50>
new_maxblock	
1050504
old_maxblock	
65536
options	
{'compress_level': 1, 'optimize': 0, 'progressive': 1, 'quality': 95}
outfile	
<_io.BytesIO object at 0x000001C4BEBD7830>
save	
<function save_image.<locals>.save at 0x000001C4BEB890D0>
save_kwargs	
{'compress_level': 1, 'optimize': 0, 'progressive': 1, 'quality': 95}
wrapper	
<pilkit.utils.FileWrapper object at 0x000001C4BEBBDA58>
C:\Sites\pyenv\lib\site-packages\pilkit\utils.py in save
        with quiet(): ...
▼ Local vars
Variable	Value
format	
'jpeg'
fp	
<pilkit.utils.FileWrapper object at 0x000001C4BEBBDA58>
img	
<PIL.Image.Image image mode=RGB size=728x481 at 0x1C4BEBBDC50>
options	
{'compress_level': 1, 'optimize': 0, 'progressive': 1, 'quality': 95}
C:\Sites\pyenv\lib\site-packages\pilkit\utils.py in __enter__
            self.stderr_fd = sys.__stderr__.fileno()             ...
▼ Local vars
Variable	Value
self	
<pilkit.utils.quiet object at 0x000001C4BEBBDB38>