### PR TITLE
Fix ResizeToFit when width or height is not set

### DIFF
--- a/pilkit/processors/resize.py
+++ b/pilkit/processors/resize.py
@@ -226,7 +226,7 @@ class ResizeToFit(object):
                           int(round(cur_height * ratio)))
         img = Resize(new_dimensions[0], new_dimensions[1], upscale=self.upscale).process(img)
         if self.mat_color is not None:
-            img = ResizeCanvas(self.width, self.height, self.mat_color, anchor=self.anchor).process(img)
+            img = ResizeCanvas(new_dimensions[0], new_dimensions[1], self.mat_color, anchor=self.anchor).process(img)
         return img
 
 


### PR DESCRIPTION
ResizeToFit will throw a TypeError when width or height is not set.

Since the image has already been resized by Resize, we should send ResizeToCanvas the new dimensions to avoid the TypeError.