### PR TITLE
Fix Travis CI for Python 3.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,3 +4,5 @@ envlist =
 
 [testenv]
 commands = python setup.py test
+deps =
+	py34: Pillow<6


### PR DESCRIPTION
Pillow 6 is dropping Python 3.4 support