### PR TITLE
Updating histogram entropy implementations

### DIFF
--- a/pilkit/lib.py
+++ b/pilkit/lib.py
@@ -4,7 +4,7 @@
 # depending on the installation method used.
 try:
     from PIL import Image, ImageColor, ImageChops, ImageEnhance, ImageFile, \
-            ImageFilter, ImageDraw, ImageStat
+            ImageFilter, ImageDraw, ImageStat, ImageMode
 except ImportError:
     try:
         import Image
@@ -15,6 +15,7 @@ except ImportError:
         import ImageFilter
         import ImageDraw
         import ImageStat
+        import ImageMode
     except ImportError:
         raise ImportError('PILKit was unable to import the Python Imaging Library. Please confirm it`s installed and available on your current Python path.')
 

--- a/pilkit/processors/utils.py
+++ b/pilkit/processors/utils.py
@@ -1,18 +1,22 @@
-import math
-from ..lib import Image
+from ..lib import Image, ImageMode
 
 
-def histogram_entropy(im):
+def color_count(image):
+    """ Return the number of color values in the input image --
+        this is the number of pixels times the band count
+        of the image.
     """
-    Calculate the entropy of an images' histogram. Used for "smart cropping" in easy-thumbnails;
-    see: https://raw.github.com/SmileyChris/easy-thumbnails/master/easy_thumbnails/utils.py
+    mode_descriptor = ImageMode.getmode(image.mode)
+    width, height = image.size
+    return width * height * len(mode_descriptor.bands)
 
-    """
-    if not isinstance(im, Image.Image):
-        return 0  # Fall back to a constant entropy.
+def histogram_entropy_py(image):
+    """ Calculate the entropy of an images' histogram. """
+    from math import log2, fsum
+    histosum = float(color_count(image))
+    histonorm = (histocol / histosum for histocol in image.histogram())
+    return -fsum(p * log2(p) for p in histonorm if p != 0.0)
 
-    histogram = im.histogram()
-    hist_ceil = float(sum(histogram))
-    histonorm = [histocol / hist_ceil for histocol in histogram]
-
-    return -sum([p * math.log(p, 2) for p in histonorm if p != 0])
+# Select the Pillow native histogram entropy function - if
+# available - and fall back to the Python implementation:
+histogram_entropy = getattr(Image.Image, 'entropy', histogram_entropy_py)


### PR DESCRIPTION
As of version 6.1.0, the Pillow imaging library’s C module includes an optimized native entropy method:

• https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#610-2019-07-01

This change detects and selects this new native method, if it is available in the version of Pillow upon which `pilkit` finds itself running.

Additionally, an optimized version of the existing Python entropy method is furnished as a fallback: rather than summing the entire histogram value set, the function calculates the product of the image dimensions and band count to arrive at the same number. It also uses generator expressions and the specialized `math.fsum(…)` and `math.log2(…)` library calls to improve on the performance of its predecessor without altering the algorithm.

The appropriate image-entropy function is then conditionally ensconced in the `pilkit.processors.utils` module, at module-load time.