### PR TITLE
ResizeCanvas processor fixed

### DIFF
--- a/pilkit/processors/resize.py
+++ b/pilkit/processors/resize.py
@@ -153,10 +153,28 @@ class ResizeCanvas(object):
 
         if self.anchor:
             anchor = Anchor.get_tuple(self.anchor)
-            trim_x, trim_y = self.width - original_width, \
-                    self.height - original_height
-            x = int(float(trim_x) * float(anchor[0]))
-            y = int(float(trim_y) * float(anchor[1]))
+            anchor_x = original_width * anchor[0]
+            anchor_y = original_height * anchor[1]
+            delta_x = self.width - original_width
+            delta_y = self.height - original_height
+            if delta_y == 0:
+                # taller image than original
+                if anchor_x > original_width - self.width/2:
+                    anchor_x = original_width - self.width/2
+                elif anchor_x < self.width/2:
+                    anchor_x = self.width/2
+                x = self.width/2 - anchor_x
+                y = 0
+            else:
+                # wider image than original
+                if anchor_y > original_height - self.height/2:
+                    anchor_y = original_height - self.height/2
+                elif anchor_y < self.height/2:
+                    anchor_y = self.height/2
+                x = 0
+                y = self.height/2 - anchor_y
+            x = int(x)
+            y = int(y)
         else:
             x, y = self.x, self.y
 


### PR DESCRIPTION
For `anchor` other than the default 9 options (center, 4 edges, and 4 corners), processing didn't work correctly. The offset was always vague.