### PR TITLE
Added WebP as a transparency format

### DIFF
--- a/pilkit/utils.py
+++ b/pilkit/utils.py
@@ -6,7 +6,7 @@ from .exceptions import UnknownExtension, UnknownFormat
 from .lib import Image, ImageFile, StringIO, string_types
 
 
-RGBA_TRANSPARENCY_FORMATS = ['PNG']
+RGBA_TRANSPARENCY_FORMATS = ['PNG', 'WEBP']
 PALETTE_TRANSPARENCY_FORMATS = ['PNG', 'GIF']
 DEFAULT_EXTENSIONS = {
     'JPEG': '.jpg',


### PR DESCRIPTION
WebP conversions were being made opaque even though they support transparency. I've added it to the RGBA_TRANSPARENCY_FORMATS list to preserve transparency.