### PR TITLE
Update deprecated Image.Transpose usage

### DIFF
--- a/pilkit/lib.py
+++ b/pilkit/lib.py
@@ -3,19 +3,19 @@
 # Required PIL classes may or may not be available from the root namespace
 # depending on the installation method used.
 try:
-    from PIL import Image, ImageColor, ImageChops, ImageEnhance, ImageFile, \
-            ImageFilter, ImageDraw, ImageStat, ImageMode
+    from PIL import (Image, ImageChops, ImageColor, ImageDraw, ImageEnhance,
+                     ImageFile, ImageFilter, ImageMode, ImageStat)
 except ImportError:
     try:
         import Image
-        import ImageColor
         import ImageChops
+        import ImageColor
+        import ImageDraw
         import ImageEnhance
         import ImageFile
         import ImageFilter
-        import ImageDraw
-        import ImageStat
         import ImageMode
+        import ImageStat
     except ImportError:
         raise ImportError('PILKit was unable to import the Python Imaging Library. Please confirm it`s installed and available on your current Python path.')
 
@@ -34,3 +34,9 @@ try:
     string_types = [basestring, str]
 except NameError:
     string_types = [str]
+
+
+try:
+    from PIL.Image import Transpose as PIL_TRANSPOSE
+except ImportError:
+    PIL_TRANSPOSE = Image

--- a/pilkit/processors/base.py
+++ b/pilkit/processors/base.py
@@ -1,4 +1,4 @@
-from pilkit.lib import Image, ImageColor, ImageEnhance
+from pilkit.lib import PIL_TRANSPOSE, Image, ImageColor, ImageEnhance
 
 
 class ProcessorPipeline(list):
@@ -116,11 +116,11 @@ class Transpose(object):
 
     """
     AUTO = 'auto'
-    FLIP_HORIZONTAL = Image.FLIP_LEFT_RIGHT
-    FLIP_VERTICAL = Image.FLIP_TOP_BOTTOM
-    ROTATE_90 = Image.ROTATE_90
-    ROTATE_180 = Image.ROTATE_180
-    ROTATE_270 = Image.ROTATE_270
+    FLIP_HORIZONTAL = PIL_TRANSPOSE.FLIP_LEFT_RIGHT
+    FLIP_VERTICAL = PIL_TRANSPOSE.FLIP_TOP_BOTTOM
+    ROTATE_90 = PIL_TRANSPOSE.ROTATE_90
+    ROTATE_180 = PIL_TRANSPOSE.ROTATE_180
+    ROTATE_270 = PIL_TRANSPOSE.ROTATE_270
 
     methods = [AUTO]
     _EXIF_ORIENTATION_STEPS = {


### PR DESCRIPTION
Looks like Pillow has updated the location of expected transpose usages. I believe this fixes it but would appreciate a review – it has been a looooong time since I've been in the habit of contributing to python libs!

```
site-packages/pilkit/processors/base.py:122: DeprecationWarning: ROTATE_180 is deprecated and will be removed in Pillow 10 (2023-07-01). Use Transpose.ROTATE_180 instead.
    ROTATE_180 = Image.ROTATE_180

.venv/lib/python3.9/site-packages/pilkit/processors/base.py:123
pilkit/processors/base.py:123: DeprecationWarning: ROTATE_270 is deprecated and will be removed in Pillow 10 (2023-07-01). Use Transpose.ROTATE_270 instead.
    ROTATE_270 = Image.ROTATE_270
```