### PR TITLE
#58 updated image deprecations for Pillow 10

### DIFF
--- a/pilkit/processors/base.py
+++ b/pilkit/processors/base.py
@@ -116,11 +116,11 @@ class Transpose(object):
 
     """
     AUTO = 'auto'
-    FLIP_HORIZONTAL = Image.FLIP_LEFT_RIGHT
-    FLIP_VERTICAL = Image.FLIP_TOP_BOTTOM
-    ROTATE_90 = Image.ROTATE_90
-    ROTATE_180 = Image.ROTATE_180
-    ROTATE_270 = Image.ROTATE_270
+    FLIP_HORIZONTAL = Image.Transpose.FLIP_HORIZONTAL
+    FLIP_VERTICAL = Image.Transpose.FLIP_VERTICAL
+    ROTATE_90 = Image.Transpose.ROTATE_90
+    ROTATE_180 = Image.Transpose.ROTATE_180
+    ROTATE_270 = Image.Transpose.ROTATE_270
 
     methods = [AUTO]
     _EXIF_ORIENTATION_STEPS = {

--- a/pilkit/utils.py
+++ b/pilkit/utils.py
@@ -311,7 +311,7 @@ def prepare_image(img, format):
 
             alpha = img.split()[-1]
             mask = Image.eval(alpha, lambda a: 255 if a <= 128 else 0)
-            img = img.convert('RGB').convert('P', palette=Image.ADAPTIVE,
+            img = img.convert('RGB').convert('P', palette=Image.Palette.ADAPTIVE,
                     colors=255)
             img.paste(255, mask)
             save_kwargs['transparency'] = 255


### PR DESCRIPTION
- according to https://pillow.readthedocs.io/en/stable/deprecations.html
- `Image.ADAPTIVE` -> `Image.Palette.ADAPTIVE`
- `Image.FLIP_HORIZONTAL` -> `Image.Transpose.FLIP_HORIZONTAL`
- etc. etc.