### PR TITLE
Addresses #64, ANTIALIAS deprecated in Pillow 10

### DIFF
--- a/pilkit/processors/resize.py
+++ b/pilkit/processors/resize.py
@@ -22,7 +22,7 @@ class Resize(object):
     def process(self, img):
         if self.upscale or (self.width < img.size[0] and self.height < img.size[1]):
             img = resolve_palette(img)
-            img = img.resize((self.width, self.height), Image.ANTIALIAS)
+            img = img.resize((self.width, self.height), Image.LANCZOS)
         return img
 
 


### PR DESCRIPTION
Apparently `ANTIALIAS` and other constants *were* actually deprecated in Pillow 10 despite the warnings having been removed sometime around v9.4