### PR TITLE
Change deprecated ANTIALIAS to LANCZOS

### DIFF
--- a/pilkit/processors/resize.py
+++ b/pilkit/processors/resize.py
@@ -22,7 +22,7 @@ class Resize(object):
     def process(self, img):
         if self.upscale or (self.width < img.size[0] and self.height < img.size[1]):
             img = resolve_palette(img)
-            img = img.resize((self.width, self.height), Image.ANTIALIAS)
+            img = img.resize((self.width, self.height), Image.Resampling.LANCZOS)
         return img
 
 

--- a/pilkit/processors/resize.py
+++ b/pilkit/processors/resize.py
@@ -22,7 +22,7 @@ class Resize(object):
     def process(self, img):
         if self.upscale or (self.width < img.size[0] and self.height < img.size[1]):
             img = resolve_palette(img)
-            img = img.resize((self.width, self.height), Image.Resampling.LANCZOS)
+            img = img.resize((self.width, self.height), Image.LANCZOS)
         return img
 
 


### PR DESCRIPTION
`Image.ANTIALIAS` — no longer works in version 10
`Image.LANCZOS` — works since version 2.6, but is also deprecated
`Image.Resampling.LANCZOS` — modern version

https://github.com/matthewwithanm/pilkit/issues/64

Reference: [Pillow 10.0.0 release notes (with table of removed constants)](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants)