### PR TITLE
Fixup CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,11 +9,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/pilkit/processors/resize.py
+++ b/pilkit/processors/resize.py
@@ -22,7 +22,7 @@ class Resize(object):
     def process(self, img):
         if self.upscale or (self.width < img.size[0] and self.height < img.size[1]):
             img = resolve_palette(img)
-            img = img.resize((self.width, self.height), Image.ANTIALIAS)
+            img = img.resize((self.width, self.height), Image.LANCZOS)
         return img
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py{310,39,38,37,36,35,27},
+	py{311,310,39,38,37,36},
 	coverage-report
 
 [testenv]


### PR DESCRIPTION
This bump the base distro to ubuntu 20.04 since ubuntu 18.04 image is gone and so the ci is not running jobs. To have it working this cherry-picks a squashed version of #66.