### PR TITLE
Fix #54 use unittest.mock instead of mock

### DIFF
--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -1,5 +1,5 @@
 import os
-import mock
+from unittest import mock
 import pytest
 
 from pilkit.lib import Image, ImageDraw, ImageColor

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import os
 import io
 import pytest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from tempfile import NamedTemporaryFile
 
 from pilkit.exceptions import UnknownFormat, UnknownExtension

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py{311,310,39,38}-pillow{7,8,9,10}
+	py{311,310,39,38}-pillow{10,9,8}
 	py37-pillow{9,8,7}
 	py36-pillow{8,7}
 	coverage-report
@@ -20,7 +20,7 @@ commands = python -m pytest --cov --cov-report term-missing:skip-covered
 deps =
 	pytest
     pytest-cov
-	mock>=1.0.1
+	pillow7: Pillow~=7.2.0
 	pillow8: Pillow~=8.4.0
 	pillow9: Pillow~=9.5.0
 	pillow10: Pillow~=10.0.1


### PR DESCRIPTION
We support Python 3.6+ officially 

Fix #54 