### PR TITLE
Preserve transparency in palette-based PNG

### DIFF
--- a/pilkit/processors/utils.py
+++ b/pilkit/processors/utils.py
@@ -29,4 +29,9 @@ def resolve_palette(image):
 
     if image.palette is None:
         return image
-    return image.convert(image.palette.mode)
+
+    has_transparency = "transparency" in image.info
+    mode = image.palette.mode
+    if mode == "RGB" and has_transparency:
+        mode = "RGBA"
+    return image.convert(mode)


### PR DESCRIPTION
Fixes https://github.com/matthewwithanm/pilkit/issues/72.

The implementation is borrowed from the `Image.convert()` [method](https://github.com/python-pillow/Pillow/blob/ec3cf2cb68e66cd7c8978f2e9623c89da14dbf9a/src/PIL/Image.py#L938) of the PIL library.
