### PR TITLE
Fix border color trimming for Pillow 10+

### DIFF
--- a/pilkit/processors/crop.py
+++ b/pilkit/processors/crop.py
@@ -66,7 +66,7 @@ class TrimBorderColor(object):
                     .convert('RGBA')
             diff = ImageChops.subtract(diff, tmp)
 
-        bbox = diff.getbbox()
+        bbox = diff.getbbox(alpha_only=False)
         if bbox:
             img = _crop(img, bbox, self.sides)
         return img


### PR DESCRIPTION
Pillow 10+ added an alpha_only keyword parameter to getbbox that defaults to True.  For the border trimmer to work correctly, alpha_only must be set to False.

https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html